### PR TITLE
Use prettier plugin instead of just config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -606,6 +606,14 @@
         "jsx-ast-utils": "^2.0.1"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.12.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
@@ -738,6 +746,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1360,6 +1373,20 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,17 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jest": "^22.3.0",
     "eslint-plugin-jsx-a11y": "^6.2.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.2.0",
     "eslint-plugin-vue": "^5.2.2"
   },
   "peerDependencies": {
-    "eslint": ">=5"
+    "eslint": ">=5",
+    "prettier": ">=1"
   },
   "devDependencies": {
-    "eslint": "^5.7.0"
+    "eslint": "^5.7.0",
+    "prettier": "^1.19.1"
   }
 }

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,5 +1,4 @@
-// https://github.com/prettier/eslint-config-prettier
+// https://github.com/prettier/eslint-plugin-prettier
 module.exports = {
-  extends: ["prettier"],
-  rules: {}
+  extends: ["plugin:prettier/recommended"]
 };


### PR DESCRIPTION
This changes the optional prettier extension to use `eslint-plugin-prettier` instead of `eslint-config-prettier` (the former includes the latter anyway) and enables prettier rule reporting in eslint so we don't have to configure that in each consumer. I left prettier itself as a peerDependency so that consumers can manage the version as they see fit, but I'm open to just including it as a dep. What do others think?

Consumer config before this change:
```
// npm i -D prettier eslint-plugin-prettier
extends: [..., "brown/prettier"],
plugins: [..., "prettier"],
rules: {
  "prettier/prettier": "error",
  ...
}
```

Consumer config after this change:
```
// npm i -D prettier
extends: [..., "brown/prettier"]
```